### PR TITLE
fix header in HIV report, closes #40

### DIFF
--- a/src/minvar/reportdrm.py
+++ b/src/minvar/reportdrm.py
@@ -440,7 +440,7 @@ No HIV/HCV read found
     mpd.to_csv(path_or_buf='merged_muts_drm_annotated.csv', index=False)
     logging.info('Shape of raw merged is: %s', str(mpd.shape))
 
-    print('Mutations detected', file=rh)
+    print('\nMutations detected', file=rh)
     print('==================\n', file=rh)
     if org == 'HIV':
         # too complicated with panda, do it by hand


### PR DESCRIPTION
A insertion of a newline seems to fix the issue. I've tested it with a HIV and HCV sample.

![Screenshot 2019-08-15 at 09 11 33](https://user-images.githubusercontent.com/25775000/63078714-b52bcb80-bf3c-11e9-9627-5167f9711faa.png)

